### PR TITLE
Removed the fork badge

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,5 +12,3 @@
         <link rel="stylesheet" href="{{ site.baseurl }}/styles/main.css">
     </head>
     <body>
-<a href="https://github.com/TGAC/miso-lims"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/a6677b08c955af8400f44c6298f40e7d19cc5b2d/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f677261795f3664366436642e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png"></a>
-


### PR DESCRIPTION
Because it's slightly silly to have a fork badge that points to a different repository...