### PR TITLE
update Nokogiri gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,7 @@ GEM
       listen (= 3.0.6)
       mercenary (~> 0.3)
       minima (= 2.0.0)
-      nokogiri (= 1.6.8.1)
+      nokogiri (= 1.8.1)
       rouge (= 1.11.1)
       terminal-table (~> 1.4)
     github-pages-health-check (1.3.0)


### PR DESCRIPTION
Update to a version that doesn't have [security vulnerabilities](https://github.com/oicr-gsi/miso-docs-oicr/network/dependencies). Deployed [here](https://github.com/oicr-gsi/miso-docs-oicr/network/dependencies) to show that updating the gem doesn't break our site.